### PR TITLE
🔴 [緊急] 複数タグ選択機能の実装

### DIFF
--- a/frontend/components/post-editor.tsx
+++ b/frontend/components/post-editor.tsx
@@ -12,6 +12,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/use-toast";
+import { Multiselect, MultiselectOption } from "@/components/ui/multiselect";
 import { admin, categories as categoriesApi, tags as tagsApi } from "@/lib/api";
 import { Save, Eye, Upload } from "lucide-react";
 
@@ -202,9 +203,16 @@ export function PostEditor({ post, onSave }: PostEditorProps) {
 
           <div className="space-y-2">
             <Label htmlFor="tags">タグ</Label>
-            <div className="text-sm text-muted-foreground">
-              複数選択機能は後日実装予定
-            </div>
+            <Multiselect
+              options={tags.map((tag): MultiselectOption => ({
+                label: tag.name,
+                value: tag.id.toString()
+              }))}
+              value={watch("tag_ids").map(id => id.toString())}
+              onChange={(values) => setValue("tag_ids", values.map(v => parseInt(v)))}
+              placeholder="タグを選択"
+              disabled={isLoading}
+            />
           </div>
         </div>
 

--- a/frontend/components/ui/multiselect.tsx
+++ b/frontend/components/ui/multiselect.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import * as React from "react";
+import { ChevronDown, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export interface MultiselectOption {
+  label: string;
+  value: string;
+}
+
+interface MultiselectProps {
+  options: MultiselectOption[];
+  value: string[];
+  onChange: (value: string[]) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function Multiselect({
+  options,
+  value,
+  onChange,
+  placeholder = "選択してください",
+  disabled = false,
+  className,
+}: MultiselectProps) {
+  const [open, setOpen] = React.useState(false);
+  const dropdownRef = React.useRef<HTMLDivElement>(null);
+
+  const handleUnselect = React.useCallback((item: string) => {
+    onChange(value.filter((i) => i !== item));
+  }, [onChange, value]);
+
+  const handleSelect = React.useCallback((optionValue: string) => {
+    if (!value.includes(optionValue)) {
+      onChange([...value, optionValue]);
+    }
+  }, [onChange, value]);
+
+  // Close dropdown when clicking outside
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [open]);
+
+  const selectables = options.filter((option) => !value.includes(option.value));
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => setOpen(!open)}
+        className={cn(
+          "h-auto min-h-[2.5rem] w-full justify-between text-left",
+          className
+        )}
+        disabled={disabled}
+      >
+        <div className="flex gap-1 flex-wrap">
+          {value.length > 0 ? (
+            value.map((item) => {
+              const option = options.find((option) => option.value === item);
+              return (
+                <Badge
+                  variant="secondary"
+                  key={item}
+                  className="mr-1 mb-1"
+                >
+                  {option?.label}
+                  <button
+                    type="button"
+                    className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handleUnselect(item);
+                    }}
+                  >
+                    <X className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                  </button>
+                </Badge>
+              );
+            })
+          ) : (
+            <span className="text-muted-foreground">{placeholder}</span>
+          )}
+        </div>
+        <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+      </Button>
+      
+      {open && (
+        <div className="absolute z-50 w-full mt-1 bg-popover border rounded-md shadow-md max-h-60 overflow-auto">
+          {selectables.length > 0 ? (
+            selectables.map((option) => (
+              <div
+                key={option.value}
+                className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
+                onClick={() => handleSelect(option.value)}
+              >
+                {option.label}
+              </div>
+            ))
+          ) : (
+            <div className="px-2 py-1.5 text-sm text-muted-foreground">
+              選択可能な項目がありません
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 記事編集時に複数のタグを選択できるMultiselectコンポーネントを実装
- "複数選択機能は後日実装予定" のプレースホルダーメッセージを削除し、実際の機能に置き換え

## Test plan
- [ ] 管理画面にログイン（admin/admin123）
- [ ] 記事編集画面でタグの複数選択が動作することを確認
- [ ] 選択したタグがバッジ形式で表示されることを確認
- [ ] 個別タグの削除（X ボタン）が動作することを確認
- [ ] フォーム送信時に正しく保存されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)