### PR TITLE
feat: 読了時間表示と読書進捗バーの実装

### DIFF
--- a/frontend/components/post-card.tsx
+++ b/frontend/components/post-card.tsx
@@ -3,14 +3,16 @@
 import Link from 'next/link';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Clock, User, Image as ImageIcon } from 'lucide-react';
+import { Clock, User, Image as ImageIcon, BookOpen } from 'lucide-react';
 import { getThumbnailUrl } from '@/lib/config';
 import { useEffect, useState } from 'react';
+import { calculateReadingTime, formatReadingTime } from '@/lib/utils/reading-time';
 
 interface Post {
   id: number;
   title: string;
   slug: string;
+  content?: string;
   excerpt?: string;
   published_at: string;
   categories: Array<{ id: number; name: string; slug: string }>;
@@ -118,6 +120,12 @@ export function PostCard({ post }: PostCardProps) {
                 {formattedDate}
               </time>
             </div>
+            {post.content && (
+              <div className="flex items-center gap-1">
+                <BookOpen className="h-3 w-3" suppressHydrationWarning />
+                <span>{formatReadingTime(calculateReadingTime(post.content))}</span>
+              </div>
+            )}
           </div>
         </div>
         </div>

--- a/frontend/components/post-detail.tsx
+++ b/frontend/components/post-detail.tsx
@@ -12,6 +12,8 @@ import { getImageUrl } from "@/lib/api";
 import { useEffect, useState } from "react";
 import { useAnalytics } from "@/lib/hooks/use-analytics";
 import { usePathname } from "next/navigation";
+import { ReadingProgressBar } from "@/components/reading-progress-bar";
+import { calculateReadingTime, formatReadingTime } from "@/lib/utils/reading-time";
 
 interface Post {
   id: number;
@@ -39,6 +41,7 @@ interface PostDetailProps {
 export function PostDetail({ post }: PostDetailProps) {
   const [formattedDate, setFormattedDate] = useState<string>('');
   const pathname = usePathname();
+  const readingTime = calculateReadingTime(post.content);
   
   // アナリティクストラッキング
   useAnalytics({
@@ -59,6 +62,7 @@ export function PostDetail({ post }: PostDetailProps) {
 
   return (
     <div className="min-h-screen bg-background">
+      <ReadingProgressBar />
       <Header />
       <main className="container mx-auto px-4 py-8">
         <div className="max-w-7xl mx-auto">
@@ -131,7 +135,7 @@ export function PostDetail({ post }: PostDetailProps) {
                     <div className="grid grid-cols-2 gap-4 text-sm">
                       <div className="flex items-center gap-2">
                         <span className="text-muted-foreground">読了時間:</span>
-                        <span className="font-medium">約{Math.ceil(post.content.trim().split(/\s+/).length / 400)}分</span>
+                        <span className="font-medium">{formatReadingTime(readingTime)}</span>
                       </div>
                       <div className="flex items-center gap-2">
                         <span className="text-muted-foreground">文字数:</span>

--- a/frontend/components/reading-progress-bar.tsx
+++ b/frontend/components/reading-progress-bar.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function ReadingProgressBar() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const updateProgress = () => {
+      const scrollTop = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const scrollProgress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+      setProgress(scrollProgress);
+    };
+
+    // 初期値を設定
+    updateProgress();
+
+    // スクロールイベントをリッスン
+    window.addEventListener("scroll", updateProgress, { passive: true });
+    window.addEventListener("resize", updateProgress, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", updateProgress);
+      window.removeEventListener("resize", updateProgress);
+    };
+  }, []);
+
+  return (
+    <div className="fixed top-16 left-0 right-0 z-40 h-1 bg-secondary/30">
+      <div
+        className="h-full bg-gradient-to-r from-blue-500 to-purple-600 transition-all duration-150 ease-out shadow-sm"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  );
+}

--- a/frontend/lib/utils/reading-time.ts
+++ b/frontend/lib/utils/reading-time.ts
@@ -1,0 +1,47 @@
+/**
+ * 読了時間を計算するユーティリティ関数
+ */
+
+// 日本語の読書速度（文字/分）
+const JAPANESE_READING_SPEED = 600;
+// 英語の読書速度（単語/分）
+const ENGLISH_READING_SPEED = 200;
+
+/**
+ * テキストから読了時間を計算
+ * @param text - 記事のテキスト
+ * @returns 読了時間（分）
+ */
+export function calculateReadingTime(text: string): number {
+  if (!text) return 0;
+
+  // HTMLタグを除去
+  const plainText = text.replace(/<[^>]*>/g, '');
+  
+  // 日本語文字数をカウント（ひらがな、カタカナ、漢字）
+  const japaneseCharCount = (plainText.match(/[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/g) || []).length;
+  
+  // 英語の単語数をカウント（空白で区切られた単語）
+  const englishText = plainText.replace(/[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/g, ' ');
+  const englishWordCount = englishText.split(/\s+/).filter(word => word.length > 0).length;
+  
+  // 読了時間を計算
+  const japaneseReadingTime = japaneseCharCount / JAPANESE_READING_SPEED;
+  const englishReadingTime = englishWordCount / ENGLISH_READING_SPEED;
+  
+  const totalReadingTime = japaneseReadingTime + englishReadingTime;
+  
+  // 最小1分、小数点以下切り上げ
+  return Math.max(1, Math.ceil(totalReadingTime));
+}
+
+/**
+ * 読了時間を表示用文字列に変換
+ * @param minutes - 読了時間（分）
+ * @returns 表示用文字列
+ */
+export function formatReadingTime(minutes: number): string {
+  if (minutes < 1) return '1分未満';
+  if (minutes === 1) return '約1分';
+  return `約${minutes}分`;
+}


### PR DESCRIPTION
## Summary
- 記事の読了時間を日本語・英語混在テキストに対応して計算・表示する機能を追加
- 記事詳細ページに読書進捗をリアルタイムで表示するプログレスバーを実装
- ユーザーが記事の長さと読書進行状況を直感的に把握できるようにUXを改善

## 実装内容

### 読了時間計算機能
- 日本語（600文字/分）と英語（200単語/分）の異なる読書速度に対応
- HTMLタグを除去して正確な文字数・単語数をカウント
- 最小1分から表示し、「約○分」の形式で表示

### 読書進捗バー
- ヘッダー下に固定表示（issue #29の要件通り）
- スクロールに応じてリアルタイムで進捗を更新
- 青から紫へのグラデーションで視認性を向上

### UI改善点
- 記事詳細ページ：より正確な読了時間表示
- 記事一覧：各記事カードに読了時間を追加（BookOpenアイコン付き）

## Test plan
- [x] 記事詳細ページで進捗バーが正しく表示される
- [x] スクロールに応じて進捗バーが更新される
- [x] 日本語・英語混在の記事で読了時間が適切に計算される
- [x] 記事一覧で読了時間が表示される
- [x] ダークモードでも視認性が保たれる

🤖 Generated with [Claude Code](https://claude.ai/code)